### PR TITLE
Code Maintenance

### DIFF
--- a/OpenGL-Core/src/GLCore/Core/Application.cpp
+++ b/OpenGL-Core/src/GLCore/Core/Application.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "Application.h"
+#include "GLCore/Core/Application.h"
 
 #include "GLCore/Core/Log.h"
 #include "GLCore/Renderer/Renderer.h"
@@ -15,7 +15,7 @@ namespace GLCore {
         GLCORE_ASSERT(!s_Instance, "Application already exists!");
         s_Instance = this;
 
-        m_Window = std::unique_ptr<Window>(Window::Create({ name, width, height }));
+        m_Window = Window::Create({ name, width, height });
         m_Window->SetEventCallback(GLCORE_BIND_EVENT_FN(Application::OnEvent));
 
         Renderer::Init();
@@ -26,6 +26,7 @@ namespace GLCore {
 
     Application::~Application()
     {
+        Renderer::Shutdown();
     }
 
     void Application::Run()

--- a/OpenGL-Core/src/GLCore/Core/Layer.cpp
+++ b/OpenGL-Core/src/GLCore/Core/Layer.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "Layer.h"
+#include "GLCore/Core/Layer.h"
 
 namespace GLCore {
 

--- a/OpenGL-Core/src/GLCore/Core/LayerStack.cpp
+++ b/OpenGL-Core/src/GLCore/Core/LayerStack.cpp
@@ -1,11 +1,7 @@
 #include "glpch.h"
-#include "LayerStack.h"
+#include "GLCore/Core/LayerStack.h"
 
 namespace GLCore {
-
-    LayerStack::LayerStack()
-    {
-    }
 
     LayerStack::~LayerStack()
     {

--- a/OpenGL-Core/src/GLCore/Core/LayerStack.h
+++ b/OpenGL-Core/src/GLCore/Core/LayerStack.h
@@ -8,7 +8,7 @@ namespace GLCore{
     class LayerStack
     {
     public:
-        LayerStack();
+        LayerStack() = default;
         ~LayerStack();
 
         void PushLayer(Layer* layer);

--- a/OpenGL-Core/src/GLCore/Core/Log.cpp
+++ b/OpenGL-Core/src/GLCore/Core/Log.cpp
@@ -1,11 +1,11 @@
 #include "glpch.h"
-#include "Log.h"
+#include "GLCore/Core/Log.h"
 
-#include "spdlog/sinks/stdout_color_sinks.h"
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace GLCore {
 
-    std::shared_ptr<spdlog::logger> Log::s_Logger;
+    Ref<spdlog::logger> Log::s_Logger;
 
     void Log::Init()
     {

--- a/OpenGL-Core/src/GLCore/Core/Log.h
+++ b/OpenGL-Core/src/GLCore/Core/Log.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "GLCore/Core/Core.h"
-#include "spdlog/spdlog.h"
-#include "spdlog/fmt/ostr.h"
+
+#include <spdlog/spdlog.h>
+#include <spdlog/fmt/ostr.h>
 
 namespace GLCore {
 
@@ -11,9 +12,9 @@ namespace GLCore {
     public:
         static void Init();
 
-        inline static std::shared_ptr<spdlog::logger>& GetLogger() { return s_Logger; }
+        inline static Ref<spdlog::logger>& GetLogger() { return s_Logger; }
     private:
-        static std::shared_ptr<spdlog::logger> s_Logger;
+        static Ref<spdlog::logger> s_Logger;
     };
 
 }

--- a/OpenGL-Core/src/GLCore/Core/Window.h
+++ b/OpenGL-Core/src/GLCore/Core/Window.h
@@ -43,7 +43,7 @@ namespace GLCore {
         // void* bc we do not want to tie the window to a specify library, for example a GLFWwindow
         virtual void* GetNativeWindow() const = 0;
 
-        static Window* Create(const WindowProps& props = WindowProps());
+        static Scope<Window> Create(const WindowProps& props = WindowProps());
     };
 
 }

--- a/OpenGL-Core/src/GLCore/ImGui/ImGuiLayer.cpp
+++ b/OpenGL-Core/src/GLCore/ImGui/ImGuiLayer.cpp
@@ -1,12 +1,13 @@
 #include "glpch.h"
-#include "ImGuiLayer.h"
+#include "GLCore/ImGui/ImGuiLayer.h"
 
-#include "imgui.h"
-#include "backends/imgui_impl_glfw.h"
-#include "backends/imgui_impl_opengl3.h"
+#include <imgui.h>
+#include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_opengl3.h>
 
 #include "GLCore/Core/Application.h"
 
+// TODO : Temporary
 #include <GLFW/glfw3.h>
 #include <glad/glad.h>
 

--- a/OpenGL-Core/src/GLCore/Renderer/Buffer.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/Buffer.cpp
@@ -1,8 +1,7 @@
 #include "glpch.h"
-#include "Buffer.h"
+#include "GLCore/Renderer/Buffer.h"
 
-#include "Renderer.h"
-
+#include "GLCore/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLBuffer.h"
 
 namespace GLCore {

--- a/OpenGL-Core/src/GLCore/Renderer/GraphicsContext.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/GraphicsContext.cpp
@@ -1,25 +1,23 @@
 #include "glpch.h"
-#include "GLCore/Renderer/RendererAPI.h"
+#include "GLCore/Renderer/GraphicsContext.h"
 
-#include "Platform/OpenGL/OpenGLRendererAPI.h"
+#include "GLCore/Renderer/Renderer.h"
+#include "Platform/OpenGL/OpenGLContext.h"
 
 namespace GLCore {
-    
-    RendererAPI::API RendererAPI::s_API = RendererAPI::API::OpenGL;
 
-    Scope<RendererAPI> RendererAPI::Create()
+    Scope<GraphicsContext> GraphicsContext::Create(void* window)
     {
-        switch (s_API)
+        switch (Renderer::GetAPI())
         {
         case RendererAPI::API::None:
             GLCORE_ASSERT(false, "RendererAPI::None is currently not supported!");
             return nullptr;
         case RendererAPI::API::OpenGL:
-            return CreateScope<OpenGLRendererAPI>();
+            return CreateScope<OpenGLContext>(static_cast<GLFWwindow*>(window));
         }
 
         GLCORE_ASSERT(false, "Unknown RendererAPI!");
         return nullptr;
     }
-
 }

--- a/OpenGL-Core/src/GLCore/Renderer/GraphicsContext.h
+++ b/OpenGL-Core/src/GLCore/Renderer/GraphicsContext.h
@@ -7,6 +7,8 @@ namespace GLCore {
     public:
         virtual void Init() = 0;
         virtual void SwapBuffers() = 0;
+
+        static Scope<GraphicsContext> Create(void* window);
     };
 
 }

--- a/OpenGL-Core/src/GLCore/Renderer/OrthographicCamera.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/OrthographicCamera.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OrthographicCamera.h"
+#include "GLCore/Renderer/OrthographicCamera.h"
 
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/OpenGL-Core/src/GLCore/Renderer/OrthographicCameraController.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/OrthographicCameraController.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OrthographicCameraController.h"
+#include "GLCore/Renderer/OrthographicCameraController.h"
 
 #include "GLCore/Core/Input.h"
 #include "GLCore/Core/KeyCodes.h"

--- a/OpenGL-Core/src/GLCore/Renderer/OrthographicCameraController.h
+++ b/OpenGL-Core/src/GLCore/Renderer/OrthographicCameraController.h
@@ -2,7 +2,6 @@
 
 #include "GLCore/Renderer/OrthographicCamera.h"
 #include "GLCore/Core/Timestep.h"
-
 #include "GLCore/Events/ApplicationEvent.h"
 #include "GLCore/Events/MouseEvent.h"
 

--- a/OpenGL-Core/src/GLCore/Renderer/RenderCommand.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/RenderCommand.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "RenderCommand.h"
+#include "GLCore/Renderer/RenderCommand.h"
 
 #include "Platform/OpenGL/OpenGLRendererAPI.h"
 

--- a/OpenGL-Core/src/GLCore/Renderer/RenderCommand.h
+++ b/OpenGL-Core/src/GLCore/Renderer/RenderCommand.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RendererAPI.h"
+#include "GLCore/Renderer/RendererAPI.h"
 
 namespace GLCore {
 

--- a/OpenGL-Core/src/GLCore/Renderer/Renderer.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/Renderer.cpp
@@ -1,8 +1,8 @@
 #include "glpch.h"
-#include "Renderer.h"
+#include "GLCore/Renderer/Renderer.h"
 
 #include "Platform/OpenGL/OpenGLShader.h"
-#include "Renderer2D.h"
+#include "GLCore/Renderer/Renderer2D.h"
 
 namespace GLCore {
 
@@ -12,6 +12,11 @@ namespace GLCore {
     {
         RenderCommand::Init();
         Renderer2D::Init();
+    }
+
+    void Renderer::Shutdown()
+    {
+        Renderer2D::Shutdown();
     }
 
     void Renderer::OnWindowResize(uint32_t width, uint32_t height)

--- a/OpenGL-Core/src/GLCore/Renderer/Renderer.h
+++ b/OpenGL-Core/src/GLCore/Renderer/Renderer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "OrthographicCamera.h"
-#include "RenderCommand.h"
-#include "Shader.h"
+#include "GLCore/Renderer/OrthographicCamera.h"
+#include "GLCore/Renderer/RenderCommand.h"
+#include "GLCore/Renderer/Shader.h"
 
 namespace GLCore {
 
@@ -10,6 +10,8 @@ namespace GLCore {
     {
     public:
         static void Init();
+        static void Shutdown();
+
         static void OnWindowResize(uint32_t width, uint32_t height);
 
         static void BeginScene(OrthographicCamera& camera);

--- a/OpenGL-Core/src/GLCore/Renderer/Renderer2D.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/Renderer2D.cpp
@@ -1,9 +1,9 @@
 #include "glpch.h"
 #include "Renderer2D.h"
 
-#include "VertexArray.h"
-#include "Shader.h"
-#include "RenderCommand.h"
+#include "GLCore/Renderer/VertexArray.h"
+#include "GLCore/Renderer/Shader.h"
+#include "GLCore/Renderer/RenderCommand.h"
 
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/OpenGL-Core/src/GLCore/Renderer/Renderer2D.h
+++ b/OpenGL-Core/src/GLCore/Renderer/Renderer2D.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "OrthographicCamera.h"
-#include "Texture.h"
+#include "GLCore/Renderer/OrthographicCamera.h"
+#include "GLCore/Renderer/Texture.h"
 
 namespace GLCore {
 

--- a/OpenGL-Core/src/GLCore/Renderer/RendererAPI.h
+++ b/OpenGL-Core/src/GLCore/Renderer/RendererAPI.h
@@ -2,7 +2,7 @@
 
 #include <glm/glm.hpp>
 
-#include "VertexArray.h"
+#include "GLCore/Renderer/VertexArray.h"
 
 namespace GLCore {
 

--- a/OpenGL-Core/src/GLCore/Renderer/Shader.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/Shader.cpp
@@ -1,7 +1,7 @@
 #include "glpch.h"
-#include "Shader.h"
+#include "GLCore/Renderer/Shader.h"
 
-#include "Renderer.h"
+#include "GLCore/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLShader.h"
 
 namespace GLCore {

--- a/OpenGL-Core/src/GLCore/Renderer/Texture.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/Texture.cpp
@@ -1,7 +1,7 @@
 #include "glpch.h"
-#include "Texture.h"
+#include "GLCore/Renderer/Texture.h"
 
-#include "Renderer.h"
+#include "GLCore/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLTexture.h"
 
 namespace GLCore {

--- a/OpenGL-Core/src/GLCore/Renderer/VertexArray.cpp
+++ b/OpenGL-Core/src/GLCore/Renderer/VertexArray.cpp
@@ -1,7 +1,7 @@
 #include "glpch.h"
-#include "VertexArray.h"
+#include "GLCore/Renderer/VertexArray.h"
 
-#include "Renderer.h"
+#include "GLCore/Renderer/Renderer.h"
 #include "Platform/OpenGL/OpenGLVertexArray.h"
 
 namespace GLCore {

--- a/OpenGL-Core/src/GLCore/Utils/OpenGLDebug.cpp
+++ b/OpenGL-Core/src/GLCore/Utils/OpenGLDebug.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OpenGLDebug.h"
+#include "GLCore/Utils/OpenGLDebug.h"
 
 namespace GLCore::Utils {
 

--- a/OpenGL-Core/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/OpenGL-Core/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OpenGLBuffer.h"
+#include "Platform/OpenGL/OpenGLBuffer.h"
 
 #include <glad/glad.h>
 

--- a/OpenGL-Core/src/Platform/OpenGL/OpenGLContext.cpp
+++ b/OpenGL-Core/src/Platform/OpenGL/OpenGLContext.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OpenGLContext.h"
+#include "Platform/OpenGL/OpenGLContext.h"
 
 #include <GLFW/glfw3.h>
 #include <glad/glad.h>

--- a/OpenGL-Core/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/OpenGL-Core/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OpenGLRendererAPI.h"
+#include "Platform/OpenGL/OpenGLRendererAPI.h"
 
 #include <glad/glad.h>
 

--- a/OpenGL-Core/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/OpenGL-Core/src/Platform/OpenGL/OpenGLShader.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OpenGLShader.h"
+#include "Platform/OpenGL/OpenGLShader.h"
 
 #include <fstream>
 #include <glad/glad.h>

--- a/OpenGL-Core/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/OpenGL-Core/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -1,7 +1,7 @@
 #include "glpch.h"
-#include "OpenGLTexture.h"
+#include "Platform/OpenGL/OpenGLTexture.h"
 
-#include "stb_image.h"
+#include <stb_image.h>
 
 namespace GLCore {
 

--- a/OpenGL-Core/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/OpenGL-Core/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "OpenGLVertexArray.h"
+#include "Platform/OpenGL/OpenGLVertexArray.h"
 
 #include <glad/glad.h>
 

--- a/OpenGL-Core/src/Platform/Windows/WindowsWindow.cpp
+++ b/OpenGL-Core/src/Platform/Windows/WindowsWindow.cpp
@@ -1,5 +1,5 @@
 #include "glpch.h"
-#include "WindowsWindow.h"
+#include "Platform/Windows/WindowsWindow.h"
 
 #include "GLCore/Core/Input.h"
 #include "GLCore/Events/ApplicationEvent.h"
@@ -16,9 +16,9 @@ namespace GLCore {
         LOG_ERROR("GLFW Error ({0}): {1}", error, description);
     }
 
-    Window* Window::Create(const WindowProps& props)
+    Scope<Window> Window::Create(const WindowProps& props)
     {
-        return new WindowsWindow(props);
+        return CreateScope<WindowsWindow>(props);
     }
 
     WindowsWindow::WindowsWindow(const WindowProps& props)
@@ -47,7 +47,7 @@ namespace GLCore {
         m_Window = glfwCreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
         ++s_GLFWWindowCount;
 
-        m_Context = CreateScope<OpenGLContext>(m_Window);
+        m_Context = GraphicsContext::Create(m_Window);
         m_Context->Init();
 
         glfwSetWindowUserPointer(m_Window, &m_Data);
@@ -141,9 +141,8 @@ namespace GLCore {
         glfwDestroyWindow(m_Window);
         --s_GLFWWindowCount;
 
-        if (--s_GLFWWindowCount == 0)
+        if (s_GLFWWindowCount == 0)
         {
-            LOG_INFO("Terminating GLFW");
             glfwTerminate();
         }
     }

--- a/OpenGL-Sandbox/src/Sandbox2D.cpp
+++ b/OpenGL-Sandbox/src/Sandbox2D.cpp
@@ -1,5 +1,6 @@
 #include "Sandbox2D.h"
-#include "imgui/imgui.h"
+
+#include <imgui/imgui.h>
 
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>


### PR DESCRIPTION
- Converted remaining smart pointers to wrappers: (Create)Scope and (Create)Ref
- Fixed include statements:
      -> All includes relative to `OpenGL-Core/src`
      -> All external includes use `<>` instead of `""`
- Removed obsolete logging messages in glfw
- Call Renderer2D::Shutdown() to free memory from allocated Renderer2DStorage
- Removed traces of OpenGL in the main Renderer